### PR TITLE
TOML: compact integer underscores without a second char array

### DIFF
--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -327,18 +327,17 @@ class TomlParser {
 
         for (int i = 0; i < length; i++) {
             if (buffer[start + i] == '_') {
-                // slow path to remove underscores: copy in-place, skipping '_'
-                char[] cleaned = new char[length];
-                int pos = 0;
-                for (int j = 0; j < length; j++) {
-                    char c = buffer[start + j];
+                // slow path to remove underscores: compact into the already-owned
+                // buffer itself (chars before the first '_' are already in place),
+                // avoiding a second array allocation
+                int pos = start + i;
+                for (int j = pos + 1; j < start + length; j++) {
+                    char c = buffer[j];
                     if (c != '_') {
-                        cleaned[pos++] = c;
+                        buffer[pos++] = c;
                     }
                 }
-                buffer = cleaned;
-                start = 0;
-                length = pos;
+                length = pos - start;
                 break;
             }
         }

--- a/toml/src/test/java/tools/jackson/dataformat/toml/LongTokenTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/LongTokenTest.java
@@ -84,6 +84,27 @@ public class LongTokenTest extends TomlMapperTestBase {
         assertRadixIntegerRejected("0xa");
     }
 
+    @Test
+    public void integerUnderscoreBufferGrowth() throws IOException {
+        // Digits interleaved with underscores, long enough to force the lexer's
+        // token buffer (initial size 4000) to grow while removing the underscores,
+        // followed by another key/value pair to prove later tokens are unaffected.
+        StringBuilder digits = new StringBuilder();
+        for (int i = 0; i < SCALE; i++) {
+            digits.append((char) ('0' + (i % 10)));
+            if (i % 3 == 2 && i != SCALE - 1) {
+                digits.append('_');
+            }
+        }
+        String toml = "foo = 1" + digits + "\nbar = 42";
+
+        ObjectNode node = (ObjectNode) NO_LIMITS_MAPPER.readTree(toml);
+
+        BigInteger expected = new BigInteger("1" + digits.toString().replace("_", ""));
+        assertEquals(expected, node.get("foo").bigIntegerValue());
+        assertEquals(42, node.get("bar").intValue());
+    }
+
     private void assertRadixIntegerRejected(String prefixAndFirstDigit) throws IOException {
         final ObjectMapper mapper = newTomlMapper();
         StringBuilder toml = new StringBuilder("foo = ").append(prefixAndFirstDigit);


### PR DESCRIPTION
This is a one-commit JAIPilot Cloud follow-up on the exact current head of [FasterXML/jackson-dataformats-text#713](https://github.com/FasterXML/jackson-dataformats-text/pull/713). It targets the original contributor branch so the change can be accepted without a duplicate upstream feature PR.

### Change

Compact underscores in place in TomlParser.parseInt using the parser-owned token buffer. Characters before the first underscore are already in place, so the slow path no longer allocates and fills a second char array.

### Proof

- Exact parent: 6ce8d826f55c85c94b5ef38808e813b4d622a9d9, the current #713 head.
- The same 113 focused TOML parser tests passed before and after, including decimal, hex, octal, binary, long-boundary, buffer-growth, and following-token cases.
- Five fixed 1,000-call allocation batches on a 10,000-digit underscored integer: median allocated bytes per parse fell from 551,104 to 524,416, exactly one char array removed.
- Full ./mvnw clean verify passed 1,558 tests with zero failures or errors.

### Boundary and disclosure

Only the underscore-bearing slow path changes; integer tokens without underscores are untouched. The allocation fixture forces a very long token and is not a production-throughput claim.

JAIPilot Cloud generated and validated the patch in [skrcode/jackson-dataformats-text#2](https://github.com/skrcode/jackson-dataformats-text/pull/2). I reviewed the exact ancestry, complete two-file diff, verification evidence, and limitation before offering it here.